### PR TITLE
Improve minimax performance

### DIFF
--- a/src/chess/Board.java
+++ b/src/chess/Board.java
@@ -85,8 +85,8 @@ public class Board {
         return possibleMoves;
     }
 
-    public Deque<Move> getAllMoves() {
-        return moves;
+    public Move getLastMove() {
+        return moves.peek();
     }
 
     public Square squareAt(String fromString) {
@@ -185,7 +185,6 @@ public class Board {
                         result.append("E");
                     }
                 }
-                result.append("\n");
             }
         }
         return result.toString();

--- a/src/chess/Chess.java
+++ b/src/chess/Chess.java
@@ -7,8 +7,7 @@ import chess.players.*;
 public class Chess {
     public static void main(String[] args) {
         Board board = new Board();
-//        Player p1 = new HumanPlayer(board, Piece.Color.WHITE);
-        Player p1 = new MinimaxPlayer(board, Piece.Color.WHITE, new CombinationHeuristic());
+        Player p1 = new HumanPlayer(board, Piece.Color.WHITE);
         Player p2 = new MinimaxPlayer(board, Piece.Color.BLACK, new CombinationHeuristic());
         Player currentPlayer = p1;
         while(!p1.inCheckmate() && !p1.inStalemate() && !p2.inCheckmate()) {
@@ -25,8 +24,6 @@ public class Chess {
                 System.out.print("Black");
             }
             System.out.println(" to move");
-            // The above 5 lines used to be the commented line below, but it changed behavior for whatever reason
-            // System.out.println((currentPlayer == p1 ? "White" : "Black") + " to move");
             currentPlayer.doMove();
             currentPlayer = currentPlayer == p1 ? p2 : p1;
         }

--- a/src/chess/Chess.java
+++ b/src/chess/Chess.java
@@ -7,7 +7,8 @@ import chess.players.*;
 public class Chess {
     public static void main(String[] args) {
         Board board = new Board();
-        Player p1 = new HumanPlayer(board, Piece.Color.WHITE);
+//        Player p1 = new HumanPlayer(board, Piece.Color.WHITE);
+        Player p1 = new MinimaxPlayer(board, Piece.Color.WHITE, new CombinationHeuristic());
         Player p2 = new MinimaxPlayer(board, Piece.Color.BLACK, new CombinationHeuristic());
         Player currentPlayer = p1;
         while(!p1.inCheckmate() && !p1.inStalemate() && !p2.inCheckmate()) {

--- a/src/chess/Move.java
+++ b/src/chess/Move.java
@@ -99,7 +99,7 @@ public class Move implements Comparable<Move> {
 
     // Returns 1 if heuristic value has not been set so that TreeSet doesn't view it as a duplicate move
     public int compareTo(Move other) {
-        return heuristicValueSet ? Double.compare(heuristicValue, other.heuristicValue) : 1;
+        return heuristicValueSet || other.heuristicValueSet ? Double.compare(other.heuristicValue, heuristicValue) : 1;
     }
 
     public String toString() {

--- a/src/chess/heuristics/MaterialHeuristic.java
+++ b/src/chess/heuristics/MaterialHeuristic.java
@@ -12,9 +12,9 @@ public class MaterialHeuristic implements Heuristic {
 
     private double evaluate(Board board, Piece.Color color) {
         Set<Piece> pieces = board.getPieces(color);
-        double numPiecesAdv = pieces.size() * 0.1; // weight by 0.1 (arbitrary) as number of points matter more
-        double materialAdv = pieces.stream().mapToDouble(Piece::getValue).sum();
-        double numMovesAdv = board.getPossibleMoves(color).size() * 0.1; // weight mobility at 0.1 (arbitrary) as it may lead to aggressive playing
+        double numPiecesAdv = pieces.size() * 0.05; // weight by 0.05 (arbitrary) as number of points matter more
+        double materialAdv = pieces.stream().mapToDouble(Piece::getValue).sum() * 1.5; // weight by 1.5 as this is important
+        double numMovesAdv = board.getPossibleMoves(color).size() * 0.02; // weight mobility at 0.02 (arbitrary) as it may lead to aggressive playing
         return numPiecesAdv + materialAdv + numMovesAdv;
     }
 }

--- a/src/chess/heuristics/PositionalHeuristic.java
+++ b/src/chess/heuristics/PositionalHeuristic.java
@@ -124,8 +124,8 @@ public class PositionalHeuristic implements Heuristic {
     }
 
     private double evaluate(Board board, Piece.Color color) {
-        return board.getPieces(color).stream().mapToDouble(PositionalHeuristic::value).sum() * 0.01 // remove weight, as tables are weighted by 100
-               + (board.inCheck(oppositeColor(color)) ? inEndgame(board) ? 20 : 10 : 0);
+        return board.getPieces(color).stream().mapToDouble(PositionalHeuristic::value).sum() * 0.011 // weight by 0.011 (effectively 1.1), as tables are weighted by 100
+               + (board.inCheck(oppositeColor(color)) ? inEndgame(board) ? 6 : 3 : 0);
     }
 
     private static double value(Piece piece) {

--- a/src/chess/players/MinimaxPlayer.java
+++ b/src/chess/players/MinimaxPlayer.java
@@ -7,11 +7,11 @@ import chess.heuristics.*;
 import java.util.*;
 
 public class MinimaxPlayer extends Player {
-    public static final int DEFAULT_SEARCH_DEPTH = 2;
+    public static final int DEFAULT_SEARCH_DEPTH = 3;
 
     private final int searchDepth;
     private final Heuristic heuristic;
-    private final Map<Deque<Move>, NavigableSet<Move>> memo;
+    private final Map<String, NavigableSet<Move>> memo;
 
     public MinimaxPlayer(Board board, Piece.Color color, Heuristic heuristic) {
         this(board, color, heuristic, DEFAULT_SEARCH_DEPTH);
@@ -34,16 +34,15 @@ public class MinimaxPlayer extends Player {
 
     // For DESIGN.md: used sorted set instead of priority queue because wanted to iterate over it without destroying it
     private Move negamax(Piece.Color color, int depth, double alpha, double beta) {
-        // Create a new deque to avoid weirdness with reference semantics
-        Deque<Move> allMoves = new ArrayDeque<>(board.getAllMoves());
-        Move start = allMoves.peek();
+        String boardState = board.stateString();
+        Move start = board.getLastMove();
         if (depth == 0) {
             // If start is null here something went wrong. start should never be null
             assert start != null;
             start.calculateHeuristicValue(heuristic, board, color);
             return start;
         }
-        NavigableSet<Move> moves = memo.containsKey(allMoves) ? memo.get(allMoves) : new TreeSet<>(getPossibleMoves());
+        NavigableSet<Move> moves = memo.containsKey(boardState) ? memo.get(boardState) : new TreeSet<>(getPossibleMoves());
         NavigableSet<Move> result = new TreeSet<>();
         // This reverses getPossibleMoves too, but it doesn't matter as they're in random order (I think)
         for (Move m : moves.descendingSet()) {
@@ -66,7 +65,7 @@ public class MinimaxPlayer extends Player {
                 break;
             }
         }
-        memo.put(allMoves, result);
+        memo.put(boardState, result);
 //        System.out.println("Depth: " + depth + " " + color + " " + " " + result.first().getHeuristicValue() + " " + result.last().getHeuristicValue());
 //        System.out.println("Selected: " + (result.isEmpty() ? null : result.last().getHeuristicValue()));
         return result.isEmpty() ? null : result.last();

--- a/src/chess/players/MinimaxPlayer.java
+++ b/src/chess/players/MinimaxPlayer.java
@@ -37,7 +37,7 @@ public class MinimaxPlayer extends Player {
     }
 
     // For DESIGN.md: used sorted set instead of priority queue because wanted to iterate over it without destroying it
-    protected Move negamax(Piece.Color color, int depth, double alpha, double beta) {
+    private Move negamax(Piece.Color color, int depth, double alpha, double beta) {
         String boardState = board.stateString();
         Move start = board.getLastMove();
         if (depth == 0) {
@@ -71,6 +71,10 @@ public class MinimaxPlayer extends Player {
         memo.put(boardState, result);
 //        System.out.println("Depth: " + depth + " " + color + " " + " " + result.first().getHeuristicValue() + " " + result.last().getHeuristicValue());
 //        System.out.println("Selected: " + (result.isEmpty() ? null : result.last().getHeuristicValue()));
+        return selectMove(result);
+    }
+
+    protected Move selectMove(SortedSet<Move> result) {
         return result.first();
     }
 }

--- a/src/chess/players/MinimaxPlayer.java
+++ b/src/chess/players/MinimaxPlayer.java
@@ -37,7 +37,7 @@ public class MinimaxPlayer extends Player {
     }
 
     // For DESIGN.md: used sorted set instead of priority queue because wanted to iterate over it without destroying it
-    private Move negamax(Piece.Color color, int depth, double alpha, double beta) {
+    protected Move negamax(Piece.Color color, int depth, double alpha, double beta) {
         String boardState = board.stateString();
         Move start = board.getLastMove();
         if (depth == 0) {

--- a/src/chess/players/MinimaxPlayer.java
+++ b/src/chess/players/MinimaxPlayer.java
@@ -8,7 +8,7 @@ import java.util.*;
 
 public class MinimaxPlayer extends Player {
     public static final int DEFAULT_SEARCH_DEPTH = 3;
-    public static final int LOW_PIECE_SEARCH_DEPTH = 8;
+    public static final int LOW_PIECE_SEARCH_DEPTH = 6;
 
     private int searchDepth;
     private final Heuristic heuristic;

--- a/src/chess/players/MinimaxPlayer.java
+++ b/src/chess/players/MinimaxPlayer.java
@@ -8,10 +8,11 @@ import java.util.*;
 
 public class MinimaxPlayer extends Player {
     public static final int DEFAULT_SEARCH_DEPTH = 3;
+    public static final int LOW_PIECE_SEARCH_DEPTH = 8;
 
-    private final int searchDepth;
+    private int searchDepth;
     private final Heuristic heuristic;
-    private final Map<String, NavigableSet<Move>> memo;
+    private final Map<String, SortedSet<Move>> memo;
 
     public MinimaxPlayer(Board board, Piece.Color color, Heuristic heuristic) {
         this(board, color, heuristic, DEFAULT_SEARCH_DEPTH);
@@ -26,6 +27,9 @@ public class MinimaxPlayer extends Player {
 
     public Move getMove() {
         Move m = null;
+        if (searchDepth < LOW_PIECE_SEARCH_DEPTH && board.fewPiecesLeft()) {
+            searchDepth = LOW_PIECE_SEARCH_DEPTH;
+        }
         for (int i = 1; i <= searchDepth; i++) {
             m = negamax(color, i, Double.NEGATIVE_INFINITY, Double.POSITIVE_INFINITY);
         }
@@ -42,10 +46,9 @@ public class MinimaxPlayer extends Player {
             start.calculateHeuristicValue(heuristic, board, color);
             return start;
         }
-        NavigableSet<Move> moves = memo.containsKey(boardState) ? memo.get(boardState) : new TreeSet<>(getPossibleMoves());
-        NavigableSet<Move> result = new TreeSet<>();
-        // This reverses getPossibleMoves too, but it doesn't matter as they're in random order (I think)
-        for (Move m : moves.descendingSet()) {
+        SortedSet<Move> moves = memo.containsKey(boardState) ? memo.get(boardState) : new TreeSet<>(getPossibleMoves());
+        SortedSet<Move> result = new TreeSet<>();
+        for (Move m : moves) {
             board.doMove(m);
             double value;
             if (board.inCheckmate(color)) {
@@ -68,7 +71,7 @@ public class MinimaxPlayer extends Player {
         memo.put(boardState, result);
 //        System.out.println("Depth: " + depth + " " + color + " " + " " + result.first().getHeuristicValue() + " " + result.last().getHeuristicValue());
 //        System.out.println("Selected: " + (result.isEmpty() ? null : result.last().getHeuristicValue()));
-        return result.isEmpty() ? null : result.last();
+        return result.first();
     }
 
 //    // For DESIGN.md: used sorted set instead of priority queue because wanted to iterate over it without destroying it

--- a/src/chess/players/SuboptimalMinimaxPlayer.java
+++ b/src/chess/players/SuboptimalMinimaxPlayer.java
@@ -7,7 +7,7 @@ import chess.heuristics.*;
 import java.util.*;
 
 public class SuboptimalMinimaxPlayer extends MinimaxPlayer {
-    private Random random;
+    private final Random random;
 
     public SuboptimalMinimaxPlayer(Board board, Piece.Color color, Heuristic heuristic) {
         this(board, color, heuristic, DEFAULT_SEARCH_DEPTH);
@@ -18,8 +18,9 @@ public class SuboptimalMinimaxPlayer extends MinimaxPlayer {
         this.random = new Random();
     }
 
+    @Override
     // For DESIGN.md: used sorted set instead of priority queue because wanted to iterate over it without destroying it
-    private Move negamax(Piece.Color color, int depth, double alpha, double beta) {
+    protected Move negamax(Piece.Color color, int depth, double alpha, double beta) {
         String boardState = board.stateString();
         Move start = board.getLastMove();
         if (depth == 0) {

--- a/src/chess/players/SuboptimalMinimaxPlayer.java
+++ b/src/chess/players/SuboptimalMinimaxPlayer.java
@@ -2,7 +2,6 @@ package chess.players;
 
 import chess.*;
 import chess.pieces.*;
-import static chess.pieces.Piece.Color.*;
 import chess.heuristics.*;
 import java.util.*;
 
@@ -15,45 +14,11 @@ public class SuboptimalMinimaxPlayer extends MinimaxPlayer {
 
     public SuboptimalMinimaxPlayer(Board board, Piece.Color color, Heuristic heuristic, int searchDepth) {
         super(board, color, heuristic, searchDepth);
-        this.random = new Random();
+        this.random = new Random(0); // TODO: UN-SEED THIS IN PRODUCTION
     }
 
     @Override
-    // For DESIGN.md: used sorted set instead of priority queue because wanted to iterate over it without destroying it
-    protected Move negamax(Piece.Color color, int depth, double alpha, double beta) {
-        String boardState = board.stateString();
-        Move start = board.getLastMove();
-        if (depth == 0) {
-            // If start is null here something went wrong. start should never be null
-            assert start != null;
-            start.calculateHeuristicValue(heuristic, board, color);
-            return start;
-        }
-        SortedSet<Move> moves = memo.containsKey(boardState) ? memo.get(boardState) : new TreeSet<>(getPossibleMoves());
-        SortedSet<Move> result = new TreeSet<>();
-        for (Move m : moves) {
-            board.doMove(m);
-            double value;
-            if (board.inCheckmate(color)) {
-                value = Double.NEGATIVE_INFINITY;
-            } else if (board.inCheckmate(oppositeColor(color))) {
-                value = Double.POSITIVE_INFINITY;
-            } else if (board.inStalemate()) {
-                value = 0;
-            } else {
-                value = -negamax(oppositeColor(color),depth - 1, -beta, -alpha).getHeuristicValue();
-            }
-            m.setHeuristicValue(value);
-            result.add(m);
-            board.undoLastMove();
-            alpha = Math.max(alpha, m.getHeuristicValue());
-            if (alpha >= beta) {
-                break;
-            }
-        }
-        memo.put(boardState, result);
-//        System.out.println("Depth: " + depth + " " + color + " " + " " + result.first().getHeuristicValue() + " " + result.last().getHeuristicValue());
-//        System.out.println("Selected: " + (result.isEmpty() ? null : result.last().getHeuristicValue()));
+    protected Move selectMove(SortedSet<Move> result) {
         if (result.first().getHeuristicValue() == Double.POSITIVE_INFINITY) {
             return result.first();
         }

--- a/src/chess/players/SuboptimalMinimaxPlayer.java
+++ b/src/chess/players/SuboptimalMinimaxPlayer.java
@@ -6,34 +6,16 @@ import static chess.pieces.Piece.Color.*;
 import chess.heuristics.*;
 import java.util.*;
 
-public class MinimaxPlayer extends Player {
-    public static final int DEFAULT_SEARCH_DEPTH = 3;
-    public static final int LOW_PIECE_SEARCH_DEPTH = 6;
+public class SuboptimalMinimaxPlayer extends MinimaxPlayer {
+    private Random random;
 
-    protected int searchDepth;
-    protected final Heuristic heuristic;
-    protected final Map<String, SortedSet<Move>> memo;
-
-    public MinimaxPlayer(Board board, Piece.Color color, Heuristic heuristic) {
+    public SuboptimalMinimaxPlayer(Board board, Piece.Color color, Heuristic heuristic) {
         this(board, color, heuristic, DEFAULT_SEARCH_DEPTH);
     }
 
-    public MinimaxPlayer(Board board, Piece.Color color, Heuristic heuristic, int searchDepth) {
-        super(board, color);
-        this.heuristic = heuristic;
-        memo = new HashMap<>();
-        this.searchDepth = searchDepth;
-    }
-
-    public Move getMove() {
-        Move m = null;
-        if (searchDepth < LOW_PIECE_SEARCH_DEPTH && board.fewPiecesLeft()) {
-            searchDepth = LOW_PIECE_SEARCH_DEPTH;
-        }
-        for (int i = 1; i <= searchDepth; i++) {
-            m = negamax(color, i, Double.NEGATIVE_INFINITY, Double.POSITIVE_INFINITY);
-        }
-        return m;
+    public SuboptimalMinimaxPlayer(Board board, Piece.Color color, Heuristic heuristic, int searchDepth) {
+        super(board, color, heuristic, searchDepth);
+        this.random = new Random();
     }
 
     // For DESIGN.md: used sorted set instead of priority queue because wanted to iterate over it without destroying it
@@ -71,6 +53,16 @@ public class MinimaxPlayer extends Player {
         memo.put(boardState, result);
 //        System.out.println("Depth: " + depth + " " + color + " " + " " + result.first().getHeuristicValue() + " " + result.last().getHeuristicValue());
 //        System.out.println("Selected: " + (result.isEmpty() ? null : result.last().getHeuristicValue()));
-        return result.first();
+        if (result.first().getHeuristicValue() == Double.POSITIVE_INFINITY) {
+            return result.first();
+        }
+        SortedSet<Move> taken = new TreeSet<>();
+        for (int i = 0; i < result.size() / 2 && random.nextBoolean(); i++) {
+            taken.add(result.first());
+            result.remove(result.first());
+        }
+        Move selected = result.first();
+        result.addAll(taken);
+        return selected;
     }
 }

--- a/src/chess/players/SuboptimalMinimaxPlayer.java
+++ b/src/chess/players/SuboptimalMinimaxPlayer.java
@@ -14,7 +14,7 @@ public class SuboptimalMinimaxPlayer extends MinimaxPlayer {
 
     public SuboptimalMinimaxPlayer(Board board, Piece.Color color, Heuristic heuristic, int searchDepth) {
         super(board, color, heuristic, searchDepth);
-        this.random = new Random(0); // TODO: UN-SEED THIS IN PRODUCTION
+        this.random = new Random();
     }
 
     @Override

--- a/src/chess/players/WorstMinimaxPlayer.java
+++ b/src/chess/players/WorstMinimaxPlayer.java
@@ -1,0 +1,21 @@
+package chess.players;
+
+import chess.*;
+import chess.pieces.*;
+import chess.heuristics.*;
+import java.util.*;
+
+public class WorstMinimaxPlayer extends MinimaxPlayer {
+    public WorstMinimaxPlayer(Board board, Piece.Color color, Heuristic heuristic) {
+        this(board, color, heuristic, DEFAULT_SEARCH_DEPTH);
+    }
+
+    public WorstMinimaxPlayer(Board board, Piece.Color color, Heuristic heuristic, int searchDepth) {
+        super(board, color, heuristic, searchDepth);
+    }
+
+    @Override
+    protected Move selectMove(SortedSet<Move> result) {
+        return result.last();
+    }
+}


### PR DESCRIPTION
This pull request improves the minimax algorithm in performance and memoization and includes adjustments to heuristic function weighting. This also adds new players that use the minimax algorithm: ```SuboptimalMinimaxPlayer``` and ```WorstMinimaxPlayer```. 

```SuboptimalMinimaxPlayer``` randomly chooses a move that has been explored with the highest probability of choosing the best move. The chosen move is the median-ranked move in the worst case.

```WorstMinimaxPlayer``` always chooses the lowest-ranked move that has been explored, making it easy for a human opponent to win. However, it assumes its opponent also chooses the lowest-ranked move, which could lead to unexpected behavior. I might address this in a later fix.